### PR TITLE
invalid type mapping

### DIFF
--- a/reparted/conversion.py
+++ b/reparted/conversion.py
@@ -141,7 +141,7 @@ PedPartition._fields_ = [
     ('disk', POINTER(PedDisk)),
     ('geom', PedGeometry),
     ('num', c_int),
-    ('type', c_long),
+    ('type', c_int),
     ('fs_type', POINTER(PedFileSystemType)),
     ('part_list', POINTER(PedPartition)),
     ('disk_specific', c_void_p),


### PR DESCRIPTION
/**
- Partition types
  */
  enum _PedPartitionType {
      PED_PARTITION_NORMAL            = 0x00,
      PED_PARTITION_LOGICAL           = 0x01,
      PED_PARTITION_EXTENDED          = 0x02,
      PED_PARTITION_FREESPACE         = 0x04,
      PED_PARTITION_METADATA          = 0x08,
      PED_PARTITION_PROTECTED         = 0x10
  };

This was causing all partition types to be 0, resulting all kinds of havoc.
